### PR TITLE
Update to use Bytes

### DIFF
--- a/opam
+++ b/opam
@@ -7,8 +7,8 @@ tags: [ "uuid" "codec" ]
 license: "BSD3"
 depends: ["ocamlfind"]
 ocaml-version: [>= "3.10.0"]
-build: 
+build:
 [
-  ["./pkg/pkg-git" ] 
+  ["./pkg/pkg-git" ]
   ["./pkg/build" "true" ]
 ]

--- a/opam
+++ b/opam
@@ -6,7 +6,7 @@ doc: "http://erratique.ch/software/uuidm/doc/Uuidm"
 tags: [ "uuid" "codec" ]
 license: "BSD3"
 depends: ["ocamlfind"]
-ocaml-version: [>= "3.10.0"]
+ocaml-version: [>= "4.02.0"]
 build:
 [
   ["./pkg/pkg-git" ]

--- a/src/uuidm.ml
+++ b/src/uuidm.ml
@@ -26,20 +26,20 @@ let sha_1 s =
     let blen = 8 * len in
     let rem = len mod 64 in
     let mlen = if rem > 55 then len + 128 - rem else len + 64 - rem in
-    let m = String.create mlen in 
-    String.blit s 0 m 0 len;
-    String.fill m len (mlen - len) '\x00';
-    m.[len] <- '\x80';
+    let m = Bytes.create mlen in
+    Bytes.blit_string s 0 m 0 len;
+    Bytes.fill m len (mlen - len) '\x00';
+    Bytes.set m len '\x80';
     if Sys.word_size > 32 then begin
-      m.[mlen - 8] <- Char.unsafe_chr (blen lsr 56 land 0xFF);
-      m.[mlen - 7] <- Char.unsafe_chr (blen lsr 48 land 0xFF);
-      m.[mlen - 6] <- Char.unsafe_chr (blen lsr 40 land 0xFF);
-      m.[mlen - 5] <- Char.unsafe_chr (blen lsr 32 land 0xFF);
+      Bytes.set m (mlen - 8) (Char.unsafe_chr (blen lsr 56 land 0xFF));
+      Bytes.set m (mlen - 7) (Char.unsafe_chr (blen lsr 48 land 0xFF));
+      Bytes.set m (mlen - 6) (Char.unsafe_chr (blen lsr 40 land 0xFF));
+      Bytes.set m (mlen - 5) (Char.unsafe_chr (blen lsr 32 land 0xFF));
     end;
-    m.[mlen - 4] <- Char.unsafe_chr (blen lsr 24 land 0xFF);
-    m.[mlen - 3] <- Char.unsafe_chr (blen lsr 16 land 0xFF);
-    m.[mlen - 2] <- Char.unsafe_chr (blen lsr 8 land 0xFF);
-    m.[mlen - 1] <- Char.unsafe_chr (blen land 0xFF);
+    Bytes.set m (mlen - 4) (Char.unsafe_chr (blen lsr 24 land 0xFF));
+    Bytes.set m (mlen - 3) (Char.unsafe_chr (blen lsr 16 land 0xFF));
+    Bytes.set m (mlen - 2) (Char.unsafe_chr (blen lsr 8 land 0xFF));
+    Bytes.set m (mlen - 1) (Char.unsafe_chr (blen land 0xFF));
     m
   in
   (* Operations on int32 *)
@@ -65,15 +65,15 @@ let sha_1 s =
   let c = ref 0l in
   let d = ref 0l in
   let e = ref 0l in
-  for i = 0 to ((String.length m) / 64) - 1 do             (* For each block *) 
+  for i = 0 to ((Bytes.length m) / 64) - 1 do              (* For each block *)
     (* Fill w *)
     let base = i * 64 in
     for j = 0 to 15 do 
       let k = base + (j * 4) in
-      w.(j) <- sl (Int32.of_int (Char.code m.[k])) 24 lor
-               sl (Int32.of_int (Char.code m.[k + 1])) 16 lor
-               sl (Int32.of_int (Char.code m.[k + 2])) 8 lor
-               (Int32.of_int (Char.code m.[k + 3]))
+      w.(j) <- sl (Int32.of_int (Char.code (Bytes.get m k))) 24 lor
+               sl (Int32.of_int (Char.code (Bytes.get m (k + 1)))) 16 lor
+               sl (Int32.of_int (Char.code (Bytes.get m (k + 2)))) 8 lor
+               (Int32.of_int (Char.code (Bytes.get m (k + 3))))
     done;
     (* Loop *)
     a := !h0; b := !h1; c := !h2; d := !h3; e := !h4;
@@ -109,19 +109,19 @@ let sha_1 s =
     h3 := !h3 ++ !d;
     h4 := !h4 ++ !e
   done;
-  let h = String.create 20 in
+  let h = Bytes.create 20 in
   let i2s h k i =
-    h.[k] <- Char.unsafe_chr ((Int32.to_int (sr i 24)) &&& 0xFF);
-    h.[k + 1] <- Char.unsafe_chr ((Int32.to_int (sr i 16)) &&& 0xFF);
-    h.[k + 2] <- Char.unsafe_chr ((Int32.to_int (sr i 8)) &&& 0xFF);
-    h.[k + 3] <- Char.unsafe_chr ((Int32.to_int i) &&& 0xFF);
+    Bytes.set h k (Char.unsafe_chr ((Int32.to_int (sr i 24)) &&& 0xFF));
+    Bytes.set h (k + 1) (Char.unsafe_chr ((Int32.to_int (sr i 16)) &&& 0xFF));
+    Bytes.set h (k + 2) (Char.unsafe_chr ((Int32.to_int (sr i 8)) &&& 0xFF));
+    Bytes.set h (k + 3) (Char.unsafe_chr ((Int32.to_int i) &&& 0xFF));
   in
   i2s h 0 !h0;
   i2s h 4 !h1;
   i2s h 8 !h2;
   i2s h 12 !h3;
   i2s h 16 !h4;
-  h
+  Bytes.unsafe_to_string h
 
 let msg_uuid v digest ns n = 
   let u = String.sub (digest (ns ^ n)) 0 16 in

--- a/src/uuidm.ml
+++ b/src/uuidm.ml
@@ -188,7 +188,7 @@ let of_string ?(pos = 0) s =
     None 
   else
     try
-      let u = String.copy nil in
+      let u = Bytes.of_string nil in
       let i = ref 0 in
       let j = ref pos in
       let ihex c = 
@@ -202,15 +202,15 @@ let of_string ?(pos = 0) s =
 	raise Exit
       in
       let byte s j = Char.unsafe_chr (ihex s.[j] lsl 4 lor ihex s.[j + 1]) in
-      while (!i < 4) do u.[!i] <- byte s !j; j := !j + 2; incr i done; 
+      while (!i < 4) do Bytes.set u !i (byte s !j); j := !j + 2; incr i done;
       incr j;
-      while (!i < 6) do u.[!i] <- byte s !j; j := !j + 2; incr i done; 
+      while (!i < 6) do Bytes.set u !i (byte s !j); j := !j + 2; incr i done;
       incr j;
-      while (!i < 8) do u.[!i] <- byte s !j; j := !j + 2; incr i done; 
+      while (!i < 8) do Bytes.set u !i (byte s !j); j := !j + 2; incr i done;
       incr j;
-      while (!i < 10) do u.[!i] <- byte s !j; j := !j + 2; incr i done; 
+      while (!i < 10) do Bytes.set u !i (byte s !j); j := !j + 2; incr i done;
       incr j;
-      while (!i < 16) do u.[!i] <- byte s !j; j := !j + 2; incr i done;
+      while (!i < 16) do Bytes.set u !i (byte s !j); j := !j + 2; incr i done;
       Some u
     with Exit -> None
 

--- a/src/uuidm.ml
+++ b/src/uuidm.ml
@@ -217,12 +217,12 @@ let of_string ?(pos = 0) s =
 let to_string ?(upper = false) u =
   let hbase = if upper then 0x37 else 0x57 in
   let hex hbase i = Char.unsafe_chr (if i < 10 then 0x30 + i else hbase + i) in
-  let s = String.copy "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" in
+  let s = Bytes.of_string "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" in
   let i = ref 0 in
   let j = ref 0 in
   let byte s i c = 
-    s.[i] <- hex hbase (c lsr 4);
-    s.[i + 1] <- hex hbase (c land 0x0F) 
+    Bytes.set s i (hex hbase (c lsr 4));
+    Bytes.set s (i + 1) (hex hbase (c land 0x0F))
   in
   while (!j < 4) do byte s !i (Char.code u.[!j]); i := !i + 2; incr j; done;
   incr i;
@@ -233,7 +233,7 @@ let to_string ?(upper = false) u =
   while (!j < 10) do byte s !i (Char.code u.[!j]); i := !i + 2; incr j; done;
   incr i;
   while (!j < 16) do byte s !i (Char.code u.[!j]); i := !i + 2; incr j; done;
-  s
+  Bytes.unsafe_to_string s
 
 let print ?upper fmt u = Format.pp_print_string fmt (to_string ?upper u)
 

--- a/src/uuidm.ml
+++ b/src/uuidm.ml
@@ -15,13 +15,13 @@ let ns_X500 ="\x6b\xa7\xb8\x14\x9d\xad\x11\xd1\x80\xb4\x00\xc0\x4f\xd4\x30\xc8"
 
 let rand s = fun () -> Random.State.bits s                  (* 30 random bits generator. *)
 let default_rand = rand (Random.State.make_self_init ())
-                              
+
 let md5 = Digest.string
 
 (* sha-1 digest. Based on pseudo-code of RFC 3174.
    Slow and ugly but does the job. *)
-let sha_1 s =                            
-  let sha_1_pad s = 
+let sha_1 s =
+  let sha_1_pad s =
     let len = String.length s in
     let blen = 8 * len in
     let rem = len mod 64 in
@@ -68,7 +68,7 @@ let sha_1 s =
   for i = 0 to ((Bytes.length m) / 64) - 1 do              (* For each block *)
     (* Fill w *)
     let base = i * 64 in
-    for j = 0 to 15 do 
+    for j = 0 to 15 do
       let k = base + (j * 4) in
       w.(j) <- sl (Int32.of_int (Char.code (Bytes.get m k))) 24 lor
                sl (Int32.of_int (Char.code (Bytes.get m (k + 1)))) 16 lor
@@ -77,22 +77,22 @@ let sha_1 s =
     done;
     (* Loop *)
     a := !h0; b := !h1; c := !h2; d := !h3; e := !h4;
-    for t = 0 to 79 do 
-      let f, k = 
+    for t = 0 to 79 do
+      let f, k =
         if t <= 19 then (!b land !c) lor ((lnot !b) land !d), 0x5A827999l else
         if t <= 39 then !b lxor !c lxor !d, 0x6ED9EBA1l else
-        if t <= 59 then 
-	  (!b land !c) lor (!b land !d) lor (!c land !d), 0x8F1BBCDCl 
+        if t <= 59 then
+          (!b land !c) lor (!b land !d) lor (!c land !d), 0x8F1BBCDCl
 	else
         !b lxor !c lxor !d, 0xCA62C1D6l
       in
       let s = t &&& 0xF in
       if (t >= 16) then begin
-	  w.(s) <- cls 1 begin 
-	    w.((s + 13) &&& 0xF) lxor 
-	    w.((s + 8) &&& 0xF) lxor 
-	    w.((s + 2) &&& 0xF) lxor
-	    w.(s)
+          w.(s) <- cls 1 begin
+            w.((s + 13) &&& 0xF) lxor
+            w.((s + 8) &&& 0xF) lxor
+            w.((s + 2) &&& 0xF) lxor
+            w.(s)
 	  end
       end;
       let temp = (cls 5 !a) ++ f ++ !e ++ w.(s) ++ k in
@@ -123,7 +123,7 @@ let sha_1 s =
   i2s h 16 !h4;
   Bytes.unsafe_to_string h
 
-let msg_uuid v digest ns n = 
+let msg_uuid v digest ns n =
   let u = Bytes.of_string (String.sub (digest (ns ^ n)) 0 16) in
   Bytes.set u 6 (Char.unsafe_chr
     ((v lsl 4) lor (Char.code (Bytes.get u 6) land 0b0000_1111)));
@@ -131,12 +131,12 @@ let msg_uuid v digest ns n =
     (0b1000_0000 lor (Char.code (Bytes.get u 8) land 0b0011_1111)));
   Bytes.unsafe_to_string u
 
-let v3 ns n = msg_uuid 3 md5 ns n  
-let v5 ns n = msg_uuid 5 sha_1 ns n  
+let v3 ns n = msg_uuid 3 md5 ns n
+let v5 ns n = msg_uuid 5 sha_1 ns n
 
 let v4_uuid rand =
-  let r0 = rand () in 
-  let r1 = rand () in 
+  let r0 = rand () in
+  let r1 = rand () in
   let r2 = rand () in
   let r3 = rand () in
   let r4 = rand () in
@@ -159,8 +159,8 @@ let v4_uuid rand =
   Bytes.set u 15 (Char.unsafe_chr (r4 lsr 8 land 0xFF));
   Bytes.unsafe_to_string u
 
-let v4_gen seed = 
-  let rand = rand seed in     
+let v4_gen seed =
+  let rand = rand seed in
   function () -> v4_uuid rand
 
 let create = function
@@ -181,19 +181,19 @@ let unsafe_to_bytes u = u
 
 let of_string ?(pos = 0) s =
   let len = String.length s in
-  if 
-    pos + 36 > len || s.[pos + 8] <> '-' || s.[pos + 13] <> '-' || 
-    s.[pos + 18] <> '-' || s.[pos + 23] <> '-' 
-  then 
-    None 
+  if
+    pos + 36 > len || s.[pos + 8] <> '-' || s.[pos + 13] <> '-' ||
+    s.[pos + 18] <> '-' || s.[pos + 23] <> '-'
+  then
+    None
   else
     try
       let u = Bytes.of_string nil in
       let i = ref 0 in
       let j = ref pos in
-      let ihex c = 
-	let i = Char.code c in 
-	if i < 0x30 then raise Exit else 
+      let ihex c =
+	let i = Char.code c in
+	if i < 0x30 then raise Exit else
 	if i <= 0x39 then i - 0x30 else
 	if i < 0x41 then raise Exit else
 	if i <= 0x46 then i - 0x37 else
@@ -220,7 +220,7 @@ let to_string ?(upper = false) u =
   let s = Bytes.of_string "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX" in
   let i = ref 0 in
   let j = ref 0 in
-  let byte s i c = 
+  let byte s i c =
     Bytes.set s i (hex hbase (c lsr 4));
     Bytes.set s (i + 1) (hex hbase (c land 0x0F))
   in
@@ -244,7 +244,7 @@ let print ?upper fmt u = Format.pp_print_string fmt (to_string ?upper u)
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are
   met:
-        
+
   1. Redistributions of source code must retain the above copyright
      notice, this list of conditions and the following disclaimer.
 
@@ -269,5 +269,3 @@ let print ?upper fmt u = Format.pp_print_string fmt (to_string ?upper u)
   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   ---------------------------------------------------------------------------*)
-
-

--- a/src/uuidm.ml
+++ b/src/uuidm.ml
@@ -176,7 +176,7 @@ let of_bytes ?(pos = 0) s =
   if pos + 16 > len then None else
   Some (String.sub s pos 16)
 
-let to_bytes = String.copy
+let to_bytes u = Bytes.(unsafe_to_string (of_string u))
 let unsafe_to_bytes u = u
 
 let of_string ?(pos = 0) s =

--- a/src/uuidm.ml
+++ b/src/uuidm.ml
@@ -83,7 +83,7 @@ let sha_1 s =
         if t <= 39 then !b lxor !c lxor !d, 0x6ED9EBA1l else
         if t <= 59 then
           (!b land !c) lor (!b land !d) lor (!c land !d), 0x8F1BBCDCl
-	else
+        else
         !b lxor !c lxor !d, 0xCA62C1D6l
       in
       let s = t &&& 0xF in
@@ -93,7 +93,7 @@ let sha_1 s =
             w.((s + 8) &&& 0xF) lxor
             w.((s + 2) &&& 0xF) lxor
             w.(s)
-	  end
+         end
       end;
       let temp = (cls 5 !a) ++ f ++ !e ++ w.(s) ++ k in
       e := !d;
@@ -192,14 +192,14 @@ let of_string ?(pos = 0) s =
       let i = ref 0 in
       let j = ref pos in
       let ihex c =
-	let i = Char.code c in
-	if i < 0x30 then raise Exit else
-	if i <= 0x39 then i - 0x30 else
-	if i < 0x41 then raise Exit else
-	if i <= 0x46 then i - 0x37 else
-	if i < 0x61 then raise Exit else
-	if i <= 0x66 then i - 0x57 else
-	raise Exit
+        let i = Char.code c in
+        if i < 0x30 then raise Exit else
+        if i <= 0x39 then i - 0x30 else
+        if i < 0x41 then raise Exit else
+        if i <= 0x46 then i - 0x37 else
+        if i < 0x61 then raise Exit else
+        if i <= 0x66 then i - 0x57 else
+        raise Exit
       in
       let byte s j = Char.unsafe_chr (ihex s.[j] lsl 4 lor ihex s.[j + 1]) in
       while (!i < 4) do Bytes.set u !i (byte s !j); j := !j + 2; incr i done;

--- a/src/uuidm.ml
+++ b/src/uuidm.ml
@@ -140,24 +140,24 @@ let v4_uuid rand =
   let r2 = rand () in
   let r3 = rand () in
   let r4 = rand () in
-  let u = String.copy nil in
-  u.[0] <- Char.unsafe_chr (r0 land 0xFF);
-  u.[1] <- Char.unsafe_chr (r0 lsr 8 land 0xFF);
-  u.[2] <- Char.unsafe_chr (r0 lsr 16 land 0xFF);
-  u.[3] <- Char.unsafe_chr (r1 land 0xFF);
-  u.[4] <- Char.unsafe_chr (r1 lsr 8 land 0xFF);
-  u.[5] <- Char.unsafe_chr (r1 lsr 16 land 0xFF);
-  u.[6] <- Char.unsafe_chr (0b0100_0000 lor (r1 lsr 24 land 0b0000_1111));
-  u.[7] <- Char.unsafe_chr (r2 land 0xFF);
-  u.[8] <- Char.unsafe_chr (0b1000_0000 lor (r2 lsr 24 land 0b0011_1111));
-  u.[9] <- Char.unsafe_chr (r2 lsr 8 land 0xFF);
-  u.[10] <- Char.unsafe_chr (r2 lsr 16 land 0xFF);
-  u.[11] <- Char.unsafe_chr (r3 land 0xFF);
-  u.[12] <- Char.unsafe_chr (r3 lsr 8 land 0xFF);
-  u.[13] <- Char.unsafe_chr (r3 lsr 16 land 0xFF);
-  u.[14] <- Char.unsafe_chr (r4 land 0xFF);
-  u.[15] <- Char.unsafe_chr (r4 lsr 8 land 0xFF);
-  u
+  let u = Bytes.of_string nil in
+  Bytes.set u 0 (Char.unsafe_chr (r0 land 0xFF));
+  Bytes.set u 1 (Char.unsafe_chr (r0 lsr 8 land 0xFF));
+  Bytes.set u 2 (Char.unsafe_chr (r0 lsr 16 land 0xFF));
+  Bytes.set u 3 (Char.unsafe_chr (r1 land 0xFF));
+  Bytes.set u 4 (Char.unsafe_chr (r1 lsr 8 land 0xFF));
+  Bytes.set u 5 (Char.unsafe_chr (r1 lsr 16 land 0xFF));
+  Bytes.set u 6 (Char.unsafe_chr (0b0100_0000 lor (r1 lsr 24 land 0b0000_1111)));
+  Bytes.set u 7 (Char.unsafe_chr (r2 land 0xFF));
+  Bytes.set u 8 (Char.unsafe_chr (0b1000_0000 lor (r2 lsr 24 land 0b0011_1111)));
+  Bytes.set u 9 (Char.unsafe_chr (r2 lsr 8 land 0xFF));
+  Bytes.set u 10 (Char.unsafe_chr (r2 lsr 16 land 0xFF));
+  Bytes.set u 11 (Char.unsafe_chr (r3 land 0xFF));
+  Bytes.set u 12 (Char.unsafe_chr (r3 lsr 8 land 0xFF));
+  Bytes.set u 13 (Char.unsafe_chr (r3 lsr 16 land 0xFF));
+  Bytes.set u 14 (Char.unsafe_chr (r4 land 0xFF));
+  Bytes.set u 15 (Char.unsafe_chr (r4 lsr 8 land 0xFF));
+  Bytes.unsafe_to_string u
 
 let v4_gen seed = 
   let rand = rand seed in     

--- a/src/uuidm.ml
+++ b/src/uuidm.ml
@@ -124,10 +124,12 @@ let sha_1 s =
   Bytes.unsafe_to_string h
 
 let msg_uuid v digest ns n = 
-  let u = String.sub (digest (ns ^ n)) 0 16 in
-  u.[6] <- Char.unsafe_chr ((v lsl 4) lor (Char.code u.[6] land 0b0000_1111));
-  u.[8] <- Char.unsafe_chr (0b1000_0000 lor (Char.code u.[8] land 0b0011_1111));
-  u
+  let u = Bytes.of_string (String.sub (digest (ns ^ n)) 0 16) in
+  Bytes.set u 6 (Char.unsafe_chr
+    ((v lsl 4) lor (Char.code (Bytes.get u 6) land 0b0000_1111)));
+  Bytes.set u 8 (Char.unsafe_chr
+    (0b1000_0000 lor (Char.code (Bytes.get u 8) land 0b0011_1111)));
+  Bytes.unsafe_to_string u
 
 let v3 ns n = msg_uuid 3 md5 ns n  
 let v5 ns n = msg_uuid 5 sha_1 ns n  

--- a/src/uuidm.mli
+++ b/src/uuidm.mli
@@ -26,7 +26,7 @@ type t
 type version = [ 
   | `V3 of t * string (** Name based with MD5 hashing *)
   | `V4 (** Random based *) 
-  | `V5 of t * string (** Name based with SHA-1 hasing *) ]
+  | `V5 of t * string (** Name based with SHA-1 hashing *) ]
 (** The type for UUID versions and generation parameters. [`V3] and [`V5]
     specify a namespace and a name for the generation. [`V4] is random based 
     with a private state seeded with [Random.State.make_self_init], use 

--- a/src/uuidm.mli
+++ b/src/uuidm.mli
@@ -4,7 +4,7 @@
    %%NAME%% release %%VERSION%%
   ---------------------------------------------------------------------------*)
 
-(** Universally unique identifiers (UUIDs).  
+(** Universally unique identifiers (UUIDs).
 
     [Uuidm] implements 128 bits universally unique identifiers version
     3, 5 (name based with MD5, SHA-1 hashing) and 4 (random based)
@@ -13,9 +13,9 @@
     {e Release %%VERSION%% — %%MAINTAINER%% }
 
     {3 References}
-    {ul 
+    {ul
     {- P. Leach et al.
-    {e {{:http://tools.ietf.org/html/rfc4122}A universally unique identifier 
+    {e {{:http://tools.ietf.org/html/rfc4122}A universally unique identifier
      (UUID) URN Namespace}}, 2005.}} *)
 
 (** {1 UUIDs} *)
@@ -23,13 +23,13 @@
 type t
 (** The type for UUIDs. *)
 
-type version = [ 
+type version = [
   | `V3 of t * string (** Name based with MD5 hashing *)
-  | `V4 (** Random based *) 
+  | `V4 (** Random based *)
   | `V5 of t * string (** Name based with SHA-1 hashing *) ]
 (** The type for UUID versions and generation parameters. [`V3] and [`V5]
-    specify a namespace and a name for the generation. [`V4] is random based 
-    with a private state seeded with [Random.State.make_self_init], use 
+    specify a namespace and a name for the generation. [`V4] is random based
+    with a private state seeded with [Random.State.make_self_init], use
     {!v4_gen} to specify your own seed. *)
 
 val nil : t
@@ -51,7 +51,7 @@ val create : version -> t
 (** [create version] is an UUID of the given [version]. *)
 
 val v3 : t -> string -> t
-(** [v3 ns n] is [create `V3 (ns, n)]. *) 
+(** [v3 ns n] is [create `V3 (ns, n)]. *)
 
 val v5 : t -> string -> t
 (** [v5 ns n] is [create `V5 (ns, n)]. *)
@@ -76,7 +76,7 @@ val to_bytes : t -> string
 
 (**/**)
 val unsafe_to_bytes : t -> string
-(**/**) 
+(**/**)
 
 val of_string : ?pos:int -> string -> t option
 (** [of_string pos s] converts the substring of [s] starting at [pos]
@@ -100,7 +100,7 @@ val print : ?upper:bool -> Format.formatter -> t -> unit
   Redistribution and use in source and binary forms, with or without
   modification, are permitted provided that the following conditions are
   met:
-        
+
   1. Redistributions of source code must retain the above copyright
      notice, this list of conditions and the following disclaimer.
 


### PR DESCRIPTION
The 4.02.3 compiler complains loudly about deprecated `String` functions, so this patch set converts `Uuidm` to use `Bytes`, and some cosmetic cleanup. Note this bumps up the required OCaml version to 4.02.0.
