### PR TITLE
Add support for OCaml 5.00

### DIFF
--- a/opam
+++ b/opam
@@ -8,7 +8,7 @@ bug-reports: "https://github.com/dbuenzli/uuidm/issues"
 tags: [ "uuid" "codec" "org:erratique" ]
 license: "ISC"
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.08.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build} ]

--- a/src/uuidm.ml
+++ b/src/uuidm.ml
@@ -183,7 +183,7 @@ let ns_X500 ="\x6b\xa7\xb8\x14\x9d\xad\x11\xd1\x80\xb4\x00\xc0\x4f\xd4\x30\xc8"
 (* Comparing *)
 
 let equal u u' = (compare : string -> string -> int) u u' = 0
-let compare : string -> string -> int = Pervasives.compare
+let compare : string -> string -> int = Stdlib.compare
 
 (* Standard binary format *)
 


### PR DESCRIPTION
If you prefer, compatibility with OCaml < 4.08 can be kept if we add `let stdlib_compare = compare` at the top of the file, but given you already require 4.08 on cmdliner I rekon this should be alright.