### PR TITLE
Documentation fixes and updates

### DIFF
--- a/src/uuidm.mli
+++ b/src/uuidm.mli
@@ -122,7 +122,7 @@ val unsafe_of_bytes : string -> t
 val unsafe_to_bytes : t -> string
 (**/**)
 
-(** {1:fmt_ascsii US-ASCII format} *)
+(** {1:fmt_ascii US-ASCII format} *)
 
 val of_string : ?pos:int -> string -> t option
 (** [of_string pos s] converts the substring of [s] starting at [pos]

--- a/src/uuidm.mli
+++ b/src/uuidm.mli
@@ -128,7 +128,8 @@ val of_string : ?pos:int -> string -> t option
 (** [of_string pos s] converts the substring of [s] starting at [pos]
     (defaults to [0]) of the form ["XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX"]
     where X is a lower or upper case hexadecimal number to an
-    UUID. The result is [None] if a parse error occurs.  *)
+    UUID. The result is [None] if a parse error occurs. Any extra
+    characters after are ignored. *)
 
 val to_string : ?upper:bool -> t -> string
 (** [to_string u] is [u] as a string of the form


### PR DESCRIPTION
Addresses #11.

The spelling 'mistake' is in an id which may break other references (if any). I can remove that commit if you prefer.