### PR TITLE
Add warning to never use Random.get_state as input to v4_gen and make the example safe on OCaml 5

### DIFF
--- a/doc/index.mld
+++ b/doc/index.mld
@@ -15,12 +15,20 @@ See the {{!quick}quick start}.
 
 {2:random_based Random V4 UUIDs}
 
-The following [uuid] function generates V4 random UUIDs.
+The following [uuid] function generates V4 random UUIDs on OCaml 4:
 
 {[
 let uuid = Uuidm.v4_gen (Random.State.make_self_init ())
 let () = print_endline (Uuidm.to_string (uuid ()))
 let () = print_endline (Uuidm.to_string (uuid ()))
+]}
+
+However on OCaml 5 [Random.State.t] must not be shared between domains,
+otherwise there is a very slight chance you might end up generating duplicate UUIDs.
+Instead this should be used, be careful to always call [Random.split],
+ and don't use partial application:
+{[
+let uuid () = Uuidm.v4_gen (Random.split ()) ()
 ]}
 
 Make sure to read the {{!Uuidm.gen}warnings} about random generators.

--- a/src/uuidm.mli
+++ b/src/uuidm.mli
@@ -93,21 +93,29 @@ val v8 : string -> t
        pseudorandom number generator if that is an issue.}
     {- Sequences of UUIDs generated using a {!posix_ms_clock} assume
        the clock is monotonic in order to generate monotonic UUIDs.
-       If you derive it from {!Unix.gettimeofday} this may not be the case.}} *)
+       If you derive it from {!Unix.gettimeofday} this may not be the case.}}
+    {- You must ensure that the Random number state is not shared with any other Uuidm generator.
+       E.g. do not use {!Random.get_state ()} since that will result in multiple identical states,
+       yielding identical Uuids in different parts of a program.
+       Instead use {!Random.State.make_self_init ()}, or {!Random.split} (on OCaml 5+).}
+     *)
 
 type posix_ms_clock = unit -> int64
 (** The type for millisecond precision POSIX time clocks.  *)
 
 val v4_gen : Random.State.t -> (unit -> t)
 (** [v4_gen state] is a function generating {!v4} UUIDs using
-    random [state]. See {{!page-index.random_based}this example}. *)
+    random [state]. See {{!page-index.random_based}this example},
+    and read the {{!Uuidm.gen}warnings}.
+     *)
 
 val v7_non_monotonic_gen :
   now_ms:posix_ms_clock -> Random.State.t -> (unit -> t)
 (** [v7_non_monotonic_gen ~now_ms state] is a function generating
     {!v7} UUIDs using [now_ms] for the timestamp [time_ms] and random [state]
     for [rand_a] and [rand_b]. UUIDs generated in the same millisecond
-    may not be be monotonic. Use {!v7_monotonic_gen} for that. *)
+    may not be be monotonic. Use {!v7_monotonic_gen} for that.
+    Read the {{!Uuidm.gen}warnings} about random state. *)
 
 val v7_monotonic_gen :
   now_ms:posix_ms_clock -> Random.State.t -> (unit -> t option)
@@ -117,7 +125,8 @@ val v7_monotonic_gen :
     two UUID generations and [random] state for [rand_b]. This allows
     to generate up to 4096 monotonic UUIDs per millisecond. [None] is
     returned if the counter rolls over before the millisecond
-    increments. See {{!page-index.time_based}this example}.*)
+    increments. See {{!page-index.time_based}this example},
+    and read the {{!Uuidm.gen}warnings} about random state. *)
 
 (** {1:constants Constants} *)
 


### PR DESCRIPTION
Due to the deprecation of `Uuidm.v` I've seen a PR on https://github.com/xapi-project/xen-api that used random state incorrectly, in a way that would've resulted in identical Uuids in the same program.

Although this was immediately obvious to me when reviewing the PR (having dealt with the Random module in detail in the past), lets improve the documentation so that it is also more obvious for everyone.
I've also opened a PR on https://github.com/ocaml/ocaml/pull/13533 to make the standard library's documentation more explicit.

In fact it wasn't until OCaml 5 that it was documented that `Random.get_state` returns a copy, previously it (incorrectly) said that it returns the current state, which wasn't true (if it returned the current state, then it would've been updated by each request to generate random bits, and would've therefore generated unique values, at least in a single threaded program).